### PR TITLE
Increase max line length to 115 chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ for typos etc.
 
 - Use soft-tabs with a two space indent.
 
-- Keep lines fewer than 80 characters.
+- Keep lines equal to or fewer than 115 characters. *(Width of github's diff view without wrapping.)*
 
 - Never leave trailing whitespace.
 


### PR DESCRIPTION
Take max line length to <= 115 characters.

Github's diff view wraps lines of 116 characters or more, so lets use more line space in our code without going crazy. There's at least three of us that have been writing to that standard for a few months, so lets make it official in the guide at last.

The [original reason](http://discuss.fre.ag/t/changing-the-style-guide/59) we forked a style guide was to alter the max line length it seems too!
