### PR TITLE
Add section on trailing commas in array/hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,25 @@ end
   end
 ```
 
+- Last line of a multiline array or hash should end with a trailing comma. It keeps diffs much smaller when adding or deleting lines in future.
+
+```ruby
+  [
+    "one",
+    "two",
+  ]
+```
+
+- Last element of an array or hash on a single line should omit the trailing comma however.
+
+```ruby
+  # Bad
+  ["one", 2,]
+  
+  # Good
+  ["one", 2]
+```
+
 ## Documentation
 
 Use [TomDoc](http://tomdoc.org) to the best of your ability. It's pretty sweet:


### PR DESCRIPTION
We appear to be adhering to the convention of leaving a trailing newline on multiline hashes/arrays, there's plenty of our closed PRs where we either ask for them or add them un-asked, so lets make it explicit in the style guide.