### PR TITLE
Update style guide to match our coding style

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ end
   !array.include?(element)
 ```
 
-- Indent `when` as deep as `case`.
+- Indent `when` as deep as the corresponding `end`.
 
 ```ruby
   case
@@ -67,13 +67,13 @@ end
 
 
   kind = case year
-         when 1850..1889 then "Blues"
-         when 1890..1909 then "Ragtime"
-         when 1910..1929 then "New Orleans Jazz"
-         when 1930..1939 then "Swing"
-         when 1940..1950 then "Bebop"
-         else "Jazz"
-         end
+  when 1850..1889 then "Blues"
+  when 1890..1909 then "Ragtime"
+  when 1910..1929 then "New Orleans Jazz"
+  when 1930..1939 then "Swing"
+  when 1940..1950 then "Bebop"
+  else "Jazz"
+  end
 ```
 
 - Use empty lines between `def`s and to break up a method into logical paragraphs.
@@ -425,7 +425,7 @@ As you can see all the classes in a class hierarchy actually share oneclass vari
   end
 ```
 
-- Indent the `public`, `protected`, and `private` methods as much the method definitions they apply to. Leave one blank line above them.
+- Indent the `public`, `protected`, and `private` methods as much the method definitions they apply to. Leave one blank line above and below them.
 
 ```ruby
   class SomeClass
@@ -434,6 +434,7 @@ As you can see all the classes in a class hierarchy actually share oneclass vari
     end
 
     private
+
     def private_method
       # ...
     end


### PR DESCRIPTION
We currently align `when`s with the start of the line/the corresponding end. In
the case where the result of the case statement is assigned to something this
won't be lined up with the `case`.

We also almost universally add a newline after `private` as well as before it.