### PR TITLE
Add explicit note about bare rescues

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,15 +481,26 @@ As you can see all the classes in a class hierarchy actually share oneclass vari
   # bad
   begin
     # an exception occurs here
-  rescue
-    # exception handling
-  end
-
-  # still bad
-  begin
-    # an exception occurs here
   rescue Exception
     # exception handling
+  end
+```
+
+* Avoid using bare `rescue`, always specify what you are rescuing
+
+```
+  # bad - and only rescues StandardError, not Exception
+  begin
+    # an exception occurs here
+  rescue => ex
+    # exception handling
+  end
+  
+  # good
+  begin
+    # an exception occurs here
+  rescue StandardError => ex
+    # error handling here
   end
 ```
 


### PR DESCRIPTION
`rescue` only rescues `StandardError`, but our example in the style guide made it look like it rescued `Exception`. It's also surprising to come across in code if you don't remember that it only rescues `StandardError` and not `Exception`. For that reason we should be explicit and avoid it in our code, preferring `rescue StandardError` or `rescue Exception` to show what we want to rescue.