### PR TITLE
Adds a style for freezing string literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -808,6 +808,17 @@ As you can see all the classes in a class hierarchy actually share oneclass vari
   end
 ```
 
+- Add the `# frozen_string_literal: true` to the top of all files. This implicitly freezes all the string literals created in that file, which puts less pressure on garbage collection.
+
+```ruby
+# frozen_string_literal: true
+class Foo
+  def initialize
+    string = "I'm frozen!"
+  end
+end
+```
+
 ## Regular Expressions
 
 - Avoid using `$1-9` as it can be hard to track what they contain. Named groups can be used instead.


### PR DESCRIPTION
 Since Ruby 2.3, Ruby has had a MagicComment that can be added to the top of files. This makes all string literals frozen by default. This is a memory optimization; as the virtual machine doesn't allocate as many strings, it doesn't need to do as much garbage collection.

See: https://www.mikeperham.com/2018/02/28/ruby-optimization-with-one-magic-comment for an example discussion, and http://ruby-performance-book.com/blog/2016/02/is-ruby-2-3-faster-frozen-string-literals-performance.html for another view

Before merging this, we need to decide if we want to do this as a team.

Note: [RFD in progress](https://docs.google.com/document/d/10Gt9BlxUbWE09-dTY21qpUARKpk8jrHYrLnDM_6nzCc)