### PR TITLE
Fix typo in path to tomdoc generated index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Run your isolated file through the documentation parser
 
 ```bash
 yard doc --plugin tomdoc $FILENAME
-open dev/index.html
+open doc/index.html
 ```
 
 _You do not need to commit the generated `./doc` or `.yardoc` files._


### PR DESCRIPTION
The original instructions were to a non-existent path.

This PR fixes that, with reference to the generated `doc/` directory rather than `dev/`