### PR TITLE
Use spaces inside ERB tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ end
   !array.include?(element)
 ```
 
+- Use spaces inside `<%` ... `%>`.
+
+```erb
+  <% if condition %>
+  <% else %>
+  <% end %>
+```
+
 - Indent `when` as deep as the corresponding `end`.
 
 ```ruby


### PR DESCRIPTION
We usually require spaces inside ERB tags like this:

```erb
  <% if condition %>
  <% else %>
  <% end %>
```

but this isn't mentioned in our style guide.  So, this PR adds that example.